### PR TITLE
formatSlug including non-latin characters

### DIFF
--- a/src/utilities/formatSlug.ts
+++ b/src/utilities/formatSlug.ts
@@ -1,9 +1,40 @@
 import { FieldHook } from 'payload/types';
 
+const sets = [
+  { to: "a", from: "[ÀÁÂÃÄÅÆĀĂĄẠẢẤẦẨẪẬẮẰẲẴẶἀ]" },
+  { to: "c", from: "[ÇĆĈČ]" },
+  { to: "d", from: "[ÐĎĐÞ]" },
+  { to: "e", from: "[ÈÉÊËĒĔĖĘĚẸẺẼẾỀỂỄỆ]" },
+  { to: "g", from: "[ĜĞĢǴ]" },
+  { to: "h", from: "[ĤḦ]" },
+  { to: "i", from: "[ÌÍÎÏĨĪĮİỈỊ]" },
+  { to: "j", from: "[Ĵ]" },
+  { to: "ij", from: "[Ĳ]" },
+  { to: "k", from: "[Ķ]" },
+  { to: "l", from: "[ĹĻĽŁ]" },
+  { to: "m", from: "[Ḿ]" },
+  { to: "n", from: "[ÑŃŅŇ]" },
+  { to: "o", from: "[ÒÓÔÕÖØŌŎŐỌỎỐỒỔỖỘỚỜỞỠỢǪǬƠ]" },
+  { to: "oe", from: "[Œ]" },
+  { to: "p", from: "[ṕ]" },
+  { to: "r", from: "[ŔŖŘ]" },
+  { to: "s", from: "[ßŚŜŞŠȘ]" },
+  { to: "t", from: "[ŢŤ]" },
+  { to: "u", from: "[ÙÚÛÜŨŪŬŮŰŲỤỦỨỪỬỮỰƯ]" },
+  { to: "w", from: "[ẂŴẀẄ]" },
+  { to: "x", from: "[ẍ]" },
+  { to: "y", from: "[ÝŶŸỲỴỶỸ]" },
+  { to: "z", from: "[ŹŻŽ]" },
+  { to: "-", from: "[·/_,:;']" },
+];
+
 const format = (val: string): string => val.replace(/ /g, '-').replace(/[^\w-]+/g, '').toLowerCase();
 
 const formatSlug = (fallback: string): FieldHook => ({ operation, value, originalDoc, data }) => {
   if (typeof value === 'string') {
+    sets.forEach((set) => {
+      value = value.replace(new RegExp(set.from, "gi"), set.to);
+    });
     return format(value);
   }
 
@@ -11,7 +42,11 @@ const formatSlug = (fallback: string): FieldHook => ({ operation, value, origina
     const fallbackData = (data && data[fallback]) || (originalDoc && originalDoc[fallback]);
 
     if (fallbackData && typeof fallbackData === 'string') {
-      return format(fallbackData);
+      let value = fallbackData
+        sets.forEach((set) => {
+            value = value.replace(new RegExp(set.from, "gi"), set.to);
+          });
+      return format(value);
     }
   }
 


### PR DESCRIPTION
**Suggested change:** Including and slugifying non latin characters with formatSlug function, instead of omitting them completely.

### What i do:
- Added array of sets of characters to validate slug against them
- In formatSlug function body, added validation against the sets prior to the format function.

**Effect:** slug based on a title field with non-latin characters includes them, instead of removing them:
**title:** "zażółć gęśla jaźń"
**slug:** "zazolc-gesla-jazn" instead of: "za-ga-ja"
